### PR TITLE
Improve "referenced" wording

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -15,7 +15,7 @@
 de:
   github_integration:
     pull_request_opened_comment: >
-      **PR Offen:** "Pull request %{pr_number} “%{pr_title}”":%{pr_url} in "%{repository}":%{repository_url}
+      **PR Geöffnet:** "Pull request %{pr_number} “%{pr_title}”":%{pr_url} in "%{repository}":%{repository_url}
       wurde von "%{github_user}":%{github_user_url} geöffnet.
     pull_request_closed_comment: >
       **PR Geschlossen:** "Pull request %{pr_number} “%{pr_title}”":%{pr_url} in "%{repository}":%{repository_url}
@@ -24,5 +24,6 @@ de:
       **PR Merged:** "Pull request %{pr_number} “%{pr_title}”":%{pr_url} in "%{repository}":%{repository_url}
       wurde von "%{github_user}":%{github_user_url} gemerged.
     pull_request_referenced_comment: >
-      **PR Referenziert:** "Pull request %{pr_number} “%{pr_title}”":%{pr_url} in "%{repository}":%{repository_url}
-      wurde von "%{github_user}":%{github_user_url} referenziert.
+      **Referenziert in PR:** ""%{github_user}":%{github_user_url} hat dieses Arbeitspaket in
+      Pull Request %{pr_number} “%{pr_title}”":%{pr_url} in "%{repository}":%{repository_url}
+      referenziert.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,5 +24,5 @@ en:
       **PR Merged:** "Pull request %{pr_number} “%{pr_title}”":%{pr_url} for "%{repository}":%{repository_url}
       has been merged by "%{github_user}":%{github_user_url}.
     pull_request_referenced_comment: >
-      **PR Referenced:** "Pull request %{pr_number} “%{pr_title}”":%{pr_url} for "%{repository}":%{repository_url}
-      has been referenced by "%{github_user}":%{github_user_url}.
+      **Referenced in PR:** "%{github_user}":%{github_user_url} referenced this work package in
+      "Pull request %{pr_number} “%{pr_title}”":%{pr_url} on "%{repository}":%{repository_url}.


### PR DESCRIPTION
Previously, it sounded like PR had been referenced when actually the
work package has been referenced in a PR.
